### PR TITLE
zendy-api to 2.0.0-rc.20

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,9 +1,12 @@
 dependencies:
-- name: exposecontroller
-  version: 2.3.58
+- alias: expose
+  name: exposecontroller
   repository: https://chartmuseum.build.cd.jenkins-x.io
-  alias: expose
-- name: exposecontroller
   version: 2.3.58
+- alias: cleanup
+  name: exposecontroller
   repository: https://chartmuseum.build.cd.jenkins-x.io
-  alias: cleanup
+  version: 2.3.58
+- name: zendy-api
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 2.0.0-rc.20


### PR DESCRIPTION
Promote zendy-api to version 2.0.0-rc.20