### PR TITLE
zendy-cockpit to 2.0.0-rc.11

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -3,3 +3,6 @@ dependencies:
   name: zendy-api
   repository: http://jenkins-x-chartmuseum:8080
   version: 2.0.0-rc.20
+- name: zendy-cockpit
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 2.0.0-rc.11


### PR DESCRIPTION
Promote zendy-cockpit to version 2.0.0-rc.11